### PR TITLE
Force 8.4.2 version for tileset example

### DIFF
--- a/app/content/deck-gl/examples/bigquery-tileset-layer.html
+++ b/app/content/deck-gl/examples/bigquery-tileset-layer.html
@@ -1,7 +1,7 @@
 <html>
   <head>
-    <script src="https://unpkg.com/deck.gl@^8.4.0/dist.min.js"></script>
-    <script src="https://unpkg.com/@deck.gl/carto@^8.4.0/dist.min.js"></script>
+    <script src="https://unpkg.com/deck.gl@8.4.2/dist.min.js"></script>
+    <script src="https://unpkg.com/@deck.gl/carto@8.4.2/dist.min.js"></script>
     
     <script src="https://libs.cartocdn.com/mapbox-gl/v1.13.0/mapbox-gl.js"></script>
     <link href="https://libs.cartocdn.com/mapbox-gl/v1.13.0/mapbox-gl.css" rel="stylesheet" />


### PR DESCRIPTION
There is an error in ^8.4.3 and the example does not work