### PR TITLE
rename level to resolution

### DIFF
--- a/app/content/spatial-extension-bq/sql-reference/s2.md
+++ b/app/content/spatial-extension-bq/sql-reference/s2.md
@@ -53,16 +53,16 @@ SELECT bqcarto.s2.HILBERTQUADKEY_FROMID(1735346007979327488);
 ### LONGLAT_ASID
 
 {{% bannerNote type="code" %}}
-s2.LONGLAT_ASID(longitude, latitude, level)
+s2.LONGLAT_ASID(longitude, latitude, resolution)
 {{%/ bannerNote %}}
 
 **Description**
 
-Returns the S2 cell ID for a given longitude, latitude and zoom level.
+Returns the S2 cell ID for a given longitude, latitude and zoom resolution.
 
 * `longitude`: `FLOAT64` horizontal coordinate on the map.
 * `latitude`: `FLOAT64` vertical coordinate on the map.
-* `level`: `INT64` level of detail or zoom.
+* `resolution`: `INT64` level of detail or zoom.
 
 **Return type**
 
@@ -86,7 +86,7 @@ s2.ST_ASID(point, resolution)
 Returns the S2 cell ID of a given point at a given level of detail.
 
 * `point`: `GEOGRAPHY` point to get the ID from.
-* `level`: `INT64` level of detail or zoom.
+* `resolution`: `INT64` level of detail or zoom.
 
 **Return type**
 


### PR DESCRIPTION
Other modules are using "resolution" instead of "level" so did it the same for consistency.
The functions parameters have already been updated in spatial extension.

(Merge in next release)