### PR TITLE
add proxy configuration to operations

### DIFF
--- a/app/content/deployment-options/custom-deployment/operations.md
+++ b/app/content/deployment-options/custom-deployment/operations.md
@@ -41,7 +41,6 @@ When the instance is going to be installed behind a proxy it is necessary to:
    127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4 carto.lan
    ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6 carto.lan
    ```
-
 {{% bannerNote title="WARNING"%}}
 `http://192.168.3.4:1234` and `carto.lan` should be substituted for the actual **Proxy Address** and **CARTO domain** of each server.
 {{%/ bannerNote %}}


### PR DESCRIPTION
As spoken, added how to configure `proxy policy` for a `Custom Deployment`

Instructions extracted from [here](https://app.clubhouse.io/cartoteam/story/154007/pss-onprem-test-admin-map-templates-not-loading-sync-operations-fails#activity-154301) 😁 