### PR TITLE
Changes GTM to add Google Analytics

### DIFF
--- a/app/layouts/partials/head.html
+++ b/app/layouts/partials/head.html
@@ -6,12 +6,12 @@
   h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
   (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
   })(window,document.documentElement,'async-hide','dataLayer',4000,
-  {'GTM-WGSN6JK':true});</script> -->
+  {'GTM-5VD6L3J':true});</script> -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-WGSN6JK');</script>
+      })(window,document,'script','dataLayer','GTM-5VD6L3J');</script>
   <!-- End Google Tag Manager -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Julien Hennico (from our marketing team) set a new GTM container specific for the Docs, that will then send events to a new Google Analytics platform.

This PR changes the current GTM container to the new one.

With this, we'll be able to send pageviews from docs.carto.com to a Google Analytics we can analyze.