### PR TITLE
SF - correction in project name used in some examples and in the guide

### DIFF
--- a/app/content/analytics-toolbox-snowflake/examples/a-quadkey-grid-of-stores-locations-and-simple-cannibalization-analysis.md
+++ b/app/content/analytics-toolbox-snowflake/examples/a-quadkey-grid-of-stores-locations-and-simple-cannibalization-analysis.md
@@ -20,7 +20,7 @@ With a single query, we are going to calculate how many Starbucks locations fall
 WITH data AS (
   SELECT carto.QUADINT_FROMGEOGPOINT(geog, 10) AS qk,
   COUNT(*) as agg_total
-  FROM carto.starbucks_locations_usa
+  FROM sfcarto.public.starbucks_locations_usa
   WHERE geog IS NOT null
   GROUP BY qk
 )
@@ -46,7 +46,7 @@ The first method uses the `QUADINT_KRING` function with distance 1 to define an 
 WITH data AS (
   SELECT carto.QUADINT_KRING(
   carto.QUADINT_FROMGEOGPOINT(geog, 15), 1) AS qk
-  FROM carto.starbucks_locations_usa
+  FROM sfcarto.public.starbucks_locations_usa
   WHERE city = 'Las Vegas' AND geog IS NOT null
 ),
 flat_qks AS(
@@ -69,7 +69,7 @@ The second approach calculates how many Starbucks fall within a radius of three 
 WITH data AS (
   SELECT carto.QUADINT_POLYFILL(
   carto.ST_MAKEELLIPSE(geog, 3, 3, 0, 'kilometers', 12), 15) AS qk
-  FROM carto.starbucks_locations_usa
+  FROM sfcarto.public.starbucks_locations_usa
   WHERE city = 'Las Vegas' AND geog IS NOT null
 ),
 flat_qks AS(

--- a/app/content/analytics-toolbox-snowflake/examples/analyzing-store-location-coverage-using-a-voronoi-diagram.md
+++ b/app/content/analytics-toolbox-snowflake/examples/analyzing-store-location-coverage-using-a-voronoi-diagram.md
@@ -20,7 +20,7 @@ The result can be seen in the visualization below, where the color of each polyg
 WITH starbucks AS
 (
   SELECT geog
-  FROM carto.STARBUCKS_LOCATIONS_USA
+  FROM sfcarto.public.STARBUCKS_LOCATIONS_USA
   WHERE CITY = 'Atlanta' AND geog IS NOT NULL
   ORDER BY id
 ),

--- a/app/content/analytics-toolbox-snowflake/examples/minkowski-distance-to-perform-cannibalization-analysis.md
+++ b/app/content/analytics-toolbox-snowflake/examples/minkowski-distance-to-perform-cannibalization-analysis.md
@@ -21,7 +21,7 @@ WITH starbucks AS
   SELECT geog,
   ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) - 1 AS id,
   uniform(1, 10, random()) AS starbucks_size
-  FROM carto.STARBUCKS_LOCATIONS_USA
+  FROM sfcarto.public.STARBUCKS_LOCATIONS_USA
   WHERE CITY = 'Los Angeles' AND geog IS NOT NULL
   ORDER BY id
 ),

--- a/app/content/analytics-toolbox-snowflake/examples/new-supplier-offices-based-on-store-locations-clusters.md
+++ b/app/content/analytics-toolbox-snowflake/examples/new-supplier-offices-based-on-store-locations-clusters.md
@@ -21,7 +21,7 @@ First, we calculate Starbucks locations clusters using the `ST_CLUSTERKMEANS` 
 ```sql
 WITH data AS(
   SELECT geog
-  FROM carto.starbucks_locations_usa
+  FROM sfcarto.public.starbucks_locations_usa
   WHERE geog IS NOT null
   ORDER BY id
 ),
@@ -47,7 +47,7 @@ In this case we are going to use `ST_CENTEROFMASS` to calculate the location o
 ```sql
 WITH data AS(
   SELECT geog
-  FROM carto.starbucks_locations_usa
+  FROM sfcarto.public.starbucks_locations_usa
   WHERE geog IS NOT null
   ORDER BY id
 ),

--- a/app/content/analytics-toolbox-snowflake/guides/running-queries-from-builder.md
+++ b/app/content/analytics-toolbox-snowflake/guides/running-queries-from-builder.md
@@ -31,18 +31,15 @@ To get started, let's run a simple example query to cluster a set of points usin
 4. Copy and paste the following query:
 
 ```sql
--- Substitute "carto_os" by the name of the database where the Analytics Toolbox is installed
-USE DATABASE carto_os;
-
 WITH data AS(
   SELECT geog
-  FROM carto.starbucks_locations_usa
+  FROM sfcarto.public.starbucks_locations_usa
   WHERE geog IS NOT null
   ORDER BY id
 ),
 clustered_points AS
 (
-    SELECT carto.ST_CLUSTERKMEANS(ARRAY_AGG(ST_ASGEOJSON(geog)::STRING), 8) AS cluster_arr
+    SELECT sfcarto.clustering.ST_CLUSTERKMEANS(ARRAY_AGG(ST_ASGEOJSON(geog)::STRING), 8) AS cluster_arr
     FROM data
 )
 SELECT GET(VALUE, 'cluster') AS cluster, TO_GEOGRAPHY(GET(VALUE, 'geom')) AS geom


### PR DESCRIPTION
I have replaced "carto." for "sfcarto.public." in the queries in some examples and in the guide to make them reproducible today, since they were giving an error