### PR TITLE
remove carto2 ref in tilesets-guide

### DIFF
--- a/app/content/analytics-toolbox-bigquery/guides/creating-and-visualizing-tilesets.md
+++ b/app/content/analytics-toolbox-bigquery/guides/creating-and-visualizing-tilesets.md
@@ -168,7 +168,7 @@ For the latter option, you simply need to follow these simple steps:
 <img src="/img/bq-analytics-toolbox/tiler/tileset_layer_styled.png" alt="Tileset added as layer and styled" style="width:100%">
 </div>
 
-#### From the CARTO Dashboard
+<!--- #### From the CARTO Dashboard
 
 After connecting your CARTO account to BigQuery, a new _Your Tilesets_ tab will appear in the Data section of your Dashboard. This new tab shows the tilesets available to your account in a specific BigQuery project and dataset and some useful metadata. 
 
@@ -323,7 +323,7 @@ By unpublishing the tileset, we will revoke the permission mentioned above and d
 It can take up to 5 minutes to remove the map from the CDN cache.
 {{%/ bannerNote %}}
 
-Once published, you will find different options to publish the map URL on social networks, as well as the HTML code to embed the map on a website. 
+Once published, you will find different options to publish the map URL on social networks, as well as the HTML code to embed the map on a website. -->
 
 ### CLI tool
 

--- a/app/content/analytics-toolbox-redshift/overview/getting-started.md
+++ b/app/content/analytics-toolbox-redshift/overview/getting-started.md
@@ -1,6 +1,6 @@
 ## Getting started
 
-The CARTO Analytics Toolbox for Redshift is composed of a set of user-defined functions and procedures organized in a set of modules based on the functionality they offer. There are two types of modules: _core_ modules, which are [open source](https://github.com/CartoDB/carto-spatial-extension) and _advanced_, only available for CARTO customers.
+The CARTO Analytics Toolbox for Redshift is composed of a set of user-defined functions and procedures organized in a set of modules based on the functionality they offer. There are two types of modules: _core_ modules, which is [open source](https://github.com/CartoDB/carto-spatial-extension) and _advanced_, only available for CARTO customers.
 
 <div style="text-align:center" >
 <img src="/img/rs-analytics-toolbox/rs-at-modules-diagram.png" alt="Modules of the CARTO Analytics Toolbox for Redshift" style="width:100%">

--- a/app/content/analytics-toolbox-snowflake/overview/getting-started.md
+++ b/app/content/analytics-toolbox-snowflake/overview/getting-started.md
@@ -5,7 +5,7 @@ aliases:
 
 ## Getting started
 
-The CARTO Analytics Toolbox for Snowflake is composed of a set of user-defined functions and procedures organized in a set of modules based on the functionality they offer. There are two types of modules: _core_ modules, which are [open source](https://github.com/CartoDB/analytics-toolbox-core) and _advanced_.
+The CARTO Analytics Toolbox for Snowflake is composed of a set of user-defined functions and procedures organized in a set of modules based on the functionality they offer. There are two types of modules: _core_ modules, which is [open source](https://github.com/CartoDB/analytics-toolbox-core) and _advanced_.
 
 <div style="text-align:center" >
 <img src="/img/sf-analytics-toolbox/sf-at-modules-diagram.png" alt="Modules of the CARTO Analytics Toolbox for Snowflake" style="width:100%">


### PR DESCRIPTION
- Delete carto2 references in https://docs.carto.com/analytics-toolbox-bigquery/guides/creating-and-visualizing-tilesets/#cli-tool
- Correct typo in getting started page for SF and RS “which is open source”