### PR TITLE
2-new-faqs-at

### DIFF
--- a/app/content/faqs/categories/analytics-toolbox.md
+++ b/app/content/faqs/categories/analytics-toolbox.md
@@ -4,6 +4,10 @@
 
 [How can I use the functions available in the Analytics Toolbox?](#how-can-i-use-the-functions-available-in-the-analytics-toolbox)
 
+[Can I use the Analytics Toolbox from the CARTO Data Warehouse connection?](#can-i-use-the-analytics-toolbox-from-the-carto-data-warehouse-connection)
+
+[In the Analytics Toolbox for BigQuery, are there differences when using it from different GCP regions?](#in-the-analytics-toolbox-for-bigquery-are-there-differences-when-using-it-from-different-gcp-regions)
+
 ---
 
 <!-- Using level 5 headers to avoid the title being listed in the tree -->
@@ -21,5 +25,16 @@ To learn how to get access to the toolbox please visit the Documentation page fo
 - [Analytics Toolbox for Redshift](https://docs.carto.com/analytics-toolbox-redshift/overview/getting-started/)
 - [Analytics Toolbox for Databricks](https://docs.carto.com/analytics-toolbox-databricks/overview/getting-started/)
 
-In CARTO Builder, you can use the Analytics Toolbox functions in your custom SQL queries when [adding a source](https://docs.carto.com/carto-user-manual/maps/add-source/#custom-queries-using-the-analytics-toolbox) to your map.
+ In CARTO Builder, you can use the Analytics Toolbox functions in your custom SQL queries when [adding a source](https://docs.carto.com/carto-user-manual/maps/add-source/#custom-queries-using-the-analytics-toolbox) to your map.
 
+---
+##### Can I use the Analytics Toolbox from the CARTO Data Warehouse connection?
+Yes, you can. CARTO Data Warehouse connection works under the hood as a connection to Google BigQuery in the same region in which you have provisioned your CARTO organization account. Follow the same guides and reference for the [Analytics Toolbox for BigQuery](https://docs.carto.com/analytics-toolbox-bigquery/overview/getting-access/) to use this functionality from your CARTO Data Warehouse connection.
+
+---
+##### In the Analytics Toolbox for BigQuery, are there differences when using it from different GCP regions?
+Yes, there are. The projects in which we install the Analytics Toolbox functions vary depending on the [cloud region](https://cloud.google.com/compute/docs/regions-zones). In this [section of the documentation](https://docs.carto.com/analytics-toolbox-bigquery/overview/regions-table/) you can find the BigQuery Project name for the Analytics Toolbox depending on the cloud region to which you have created a connection between CARTO and BigQuery.
+
+For BigQuery connections in US and EU regions, we recommend to use the Analytics Toolbox we have enabled in US multi-region (project name: carto-un) and EU multi-region (project name: carto-un-eu)
+
+Note that this also applies if you want to leverage the Analytics Toolbox from your CARTO Data Warehouse connection.

--- a/app/content/faqs/overview.md
+++ b/app/content/faqs/overview.md
@@ -34,6 +34,8 @@
 ##### Analytics Toolbox
 * [What is CARTO’s Analytics Toolbox?](../categories/analytics-toolbox/#what-is-cartos-analytics-toolbox)
 * [How can I use the functions available in the Analytics Toolbox?](../categories/analytics-toolbox/#how-can-i-use-the-functions-available-in-the-analytics-toolbox)
+* [Can I use the Analytics Toolbox from the CARTO Data Warehouse connection?](../categories/analytics-toolbox/#can-i-use-the-analytics-toolbox-from-the-carto-data-warehouse-connection)
+* [In the Analytics Toolbox for BigQuery, are there differences when using it from different GCP regions?](../categories/analytics-toolbox/#in-the-analytics-toolbox-for-bigquery-are-there-differences-when-using-it-from-different-gcp-regions)
 
 ##### Development Tools
 * [What frameworks and libraries can I use for developing custom apps with CARTO?](../categories/development-tools/#what-frameworks-and-libraries-can-i-use-for-developing-custom-apps-with-carto)


### PR DESCRIPTION
Added to FAQ's AT section:

**Can I use the Analytics Toolbox from the CARTO Data Warehouse connection?**
Yes, you can. CARTO Data Warehouse connection works under the hood as a connection to Google BigQuery in the same region in which you have provisioned your CARTO organization account. Follow the same guides and reference for the [Analytics Toolbox for BigQuery](https://docs.carto.com/analytics-toolbox-bigquery/overview/getting-access/) to use this functionality from your CARTO Data Warehouse connection.

---

**In the Analytics Toolbox for BigQuery, are there differences when using it from different GCP regions?**
Yes, there are. The projects in which we install the Analytics Toolbox functions vary depending on the [cloud region](https://cloud.google.com/compute/docs/regions-zones). In this [section of the documentation](https://docs.carto.com/analytics-toolbox-bigquery/overview/regions-table/) you can find the BigQuery Project name for the Analytics Toolbox depending on the cloud region to which you have created a connection between CARTO and BigQuery.

For BigQuery connections in US and EU regions, we recommend to use the Analytics Toolbox we have enabled in US multi-region (project name: carto-un) and EU multi-region (project name: carto-un-eu)

Note that this also applies if you want to leverage the Analytics Toolbox from your CARTO Data Warehouse connection.