### PR TITLE
Pin H3 library version

### DIFF
--- a/app/content/deck-gl/examples/clustering-and-aggregation/h3-cluster-layer-carto2.html
+++ b/app/content/deck-gl/examples/clustering-and-aggregation/h3-cluster-layer-carto2.html
@@ -6,7 +6,7 @@
       rel="stylesheet"
     />
     <!-- h3-js is required -->
-    <script src="https://unpkg.com/h3-js"></script>
+    <script src="https://unpkg.com/h3-js@^3.0.0"></script>
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
     <script src="https://unpkg.com/@deck.gl/carto@^8.8.0/dist.min.js"></script>
     

--- a/app/content/deck-gl/examples/clustering-and-aggregation/h3-cluster-layer.html
+++ b/app/content/deck-gl/examples/clustering-and-aggregation/h3-cluster-layer.html
@@ -6,7 +6,7 @@
       rel="stylesheet"
     />
     <!-- h3-js is required -->
-    <script src="https://unpkg.com/h3-js"></script>
+    <script src="https://unpkg.com/h3-js@^3.0.0"></script>
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
     <script src="https://unpkg.com/@deck.gl/carto@^8.8.0/dist.min.js"></script>
     

--- a/app/content/deck-gl/examples/clustering-and-aggregation/h3-indexed-data-carto2.html
+++ b/app/content/deck-gl/examples/clustering-and-aggregation/h3-indexed-data-carto2.html
@@ -6,7 +6,7 @@
       rel="stylesheet"
     />
     <!-- h3-js is required -->
-    <script src="https://unpkg.com/h3-js"></script>
+    <script src="https://unpkg.com/h3-js@^3.0.0"></script>
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
     <script src="https://unpkg.com/@deck.gl/carto@^8.8.0/dist.min.js"></script>
     

--- a/app/content/deck-gl/examples/clustering-and-aggregation/h3-indexed-data.html
+++ b/app/content/deck-gl/examples/clustering-and-aggregation/h3-indexed-data.html
@@ -6,7 +6,7 @@
       rel="stylesheet"
     />
     <!-- h3-js is required -->
-    <script src="https://unpkg.com/h3-js"></script>
+    <script src="https://unpkg.com/h3-js@^3.0.0"></script>
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
     <script src="https://unpkg.com/@deck.gl/carto@^8.8.0/dist.min.js"></script>
     

--- a/app/content/google-maps/examples/advanced-examples/h3-layer-carto3.html
+++ b/app/content/google-maps/examples/advanced-examples/h3-layer-carto3.html
@@ -7,7 +7,7 @@
       rel="stylesheet"
     />
     <!-- h3-js is required -->
-    <script src="https://unpkg.com/h3-js"></script>
+    <script src="https://unpkg.com/h3-js@^3.0.0"></script>
     <script src="https://unpkg.com/deck.gl@^8.8.0/dist.min.js"></script>
     <script src="https://unpkg.com/@deck.gl/carto@^8.8.0/dist.min.js"></script>
     <script src="https://d3js.org/d3.v4.min.js"></script>


### PR DESCRIPTION
H3 has released v4, which breaks code examples. See https://github.com/visgl/deck.gl/pull/7283