### PR TITLE
Update carto for react reference up to 1.4.2

### DIFF
--- a/app/content/react/library-reference/api.md
+++ b/app/content/react/library-reference/api.md
@@ -32,6 +32,7 @@ Async function that executes a SQL query against [CARTO SQL API](https://carto.c
 | opts                          | <code>Object</code> | Optional. Additional options for the HTTP request, following the [Request](https://developer.mozilla.org/es/docs/Web/API/Request) interface |
 | opts.abortController          | <code>AbortController</code>       | To cancel the network request using [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) |
 | opts.format                   | <code>string</code> | Output format to be passed to SQL API (i.e. 'geojson')                             |
+| queryParameters               | <code> QueryParameters (@deck.gl/carto)</code> | SQL query parameters |
 {{%/ tableWrapper %}}
 
 - **Returns**: <code>Object</code> - Data returned from the SQL query execution

--- a/app/content/react/library-reference/api.md
+++ b/app/content/react/library-reference/api.md
@@ -32,7 +32,7 @@ Async function that executes a SQL query against [CARTO SQL API](https://carto.c
 | opts                          | <code>Object</code> | Optional. Additional options for the HTTP request, following the [Request](https://developer.mozilla.org/es/docs/Web/API/Request) interface |
 | opts.abortController          | <code>AbortController</code>       | To cancel the network request using [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) |
 | opts.format                   | <code>string</code> | Output format to be passed to SQL API (i.e. 'geojson')                             |
-| queryParameters               | <code> QueryParameters (@deck.gl/carto)</code> | SQL query parameters |
+| queryParameters               | <code> QueryParameters (@deck.gl/carto)</code> | Optional. SQL query parameters |
 {{%/ tableWrapper %}}
 
 - **Returns**: <code>Object</code> - Data returned from the SQL query execution

--- a/app/content/react/library-reference/api.md
+++ b/app/content/react/library-reference/api.md
@@ -71,6 +71,7 @@ React hook that allows a more powerful use of CARTO deck.gl layers, creating a s
 | props.source.type  | <code>string</code> |               | Source type. Check available types [here](/deck-gl/reference#type-string)  |
 | props.source.connection  | <code>string</code> |         | Connection name. Required only for CARTO 3.    |
 | props.source.data  | <code>string</code> |               | Table name, tileset name or SQL query.         |
+| props.source.queryParameters | <code> QueryParameters (@deck.gl/carto)</code> | | SQL query parameters |
 | [props.source.credentials] | <code>object</code> |       | (optional) Credentials for accessing the source (check the object props [here](/deck-gl/reference#setdefaultcredentials)).                                                          |
 | [props.layerConfig] | <code>Object</code> |              | (optional) { id, opacity, visible }            |
 | [props.layerConfig.id]    | <code>string</code> |        | (optional) Unique layer ID.                    |

--- a/app/content/react/library-reference/redux.md
+++ b/app/content/react/library-reference/redux.md
@@ -67,7 +67,7 @@ Action to add a **source** to the store.
 | props.credentials | <code>string</code> |  Credentials for accessing the source                                    |
 | props.connection  | <code>string</code> | Connection name. Used only for CARTO 3.  |
 | props.filtersLogicalOperator | <code>FiltersLogicalOperators</code> | Logical operation to use for combining filters. Can take the values `FiltersLogicalOperators.AND` and `FiltersLogicalOperators.OR`. Default value is `AND`. _Note: this property is only available beginning with v1.3_ |
-| props.queryParameters | <code> QueryParameters (@deck.gl/carto)</code> | SQL query parameters |
+| [props.queryParameters] | <code> QueryParameters (@deck.gl/carto)</code> | Optional. SQL query parameters |
 {{%/ tableWrapper %}}
 
 - **Example**:

--- a/app/content/react/library-reference/redux.md
+++ b/app/content/react/library-reference/redux.md
@@ -66,7 +66,8 @@ Action to add a **source** to the store.
 | props.type        | <code>string</code> | Source type. Check available types [here](/deck-gl/reference#type-string)  |
 | props.credentials | <code>string</code> |  Credentials for accessing the source                                    |
 | props.connection  | <code>string</code> | Connection name. Used only for CARTO 3.  |
-| props.filtersLogicalOperator | <code>FiltersLogicalOperators</code> | Logical operation to use for combining filters. Can take the values `FiltersLogicalOperators.AND` and `FiltersLogicalOperators.OR`. Default value is `AND`. _Note: this property is only available beginning with v1.3_
+| props.filtersLogicalOperator | <code>FiltersLogicalOperators</code> | Logical operation to use for combining filters. Can take the values `FiltersLogicalOperators.AND` and `FiltersLogicalOperators.OR`. Default value is `AND`. _Note: this property is only available beginning with v1.3_ |
+| props.queryParameters | <code> QueryParameters (@deck.gl/carto)</code> | SQL query parameters |
 {{%/ tableWrapper %}}
 
 - **Example**:

--- a/app/content/react/library-reference/widgets.md
+++ b/app/content/react/library-reference/widgets.md
@@ -609,6 +609,23 @@ Renders a `<RangeWidget />` component, binded to a source at redux.
 | [props.wrapperProps]       | `Object`      |                  | (optional) Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default) |
 {{%/ tableWrapper %}}
 
+- **Example**:
+
+  In this example, the widget would display the min/max values from the `revenue` column.
+
+  ```js
+  import { RangeWidget } from "@carto/react-widgets";
+  
+  return (
+    <RangeWidget
+      id="revenueRange"
+      title="Revenue"
+      dataSource="storesSourceId"
+      column="revenue"
+    />
+  );
+  ```
+
 
 #### ScatterPlotWidget
 

--- a/app/content/react/library-reference/widgets.md
+++ b/app/content/react/library-reference/widgets.md
@@ -588,6 +588,28 @@ Renders a `<PieWidget />` component, binded to a source at redux. From a data pe
   );
   ```
 
+#### RangeWidget
+
+Renders a `<RangeWidget />` component, binded to a source at redux.
+
+- **Input**
+
+{{% tableWrapper tab="true" overflow-layout="true" %}}
+| Param                  | Type               | Default     | Description                                        |
+| ---------------------- | ------------------ | ----------- | -------------------------------------------------- |
+| props                  | `Object`           |             |                                                    |
+| props.id               | `string`           |             | ID for the widget instance.                        |
+| props.title            | `string`           |             | Title to show in the widget header.                |
+| props.dataSource       | `string`           |             | ID of the data source to get the data from.        |
+| props.column           | `string`           |             | Name of the data source's column to get the data from. |
+| [props.min]            | `number`           |             | (optional) Set this property to use this value as the minimum value instead of calculating it from the dataset. |
+| [props.max]            | `number`           |             | (optional) Set this property to use this value as the maximum value instead of calculating it from the dataset.  |
+| [props.global]         | `bool`             |             | (optional) Enable/disable the viewport filtering in the data fetching |
+| [props.onError]        | `errorCallback` |                | (optional) _errorCallback_: Function to handle error messages from the widget. |
+| [props.wrapperProps]       | `Object`      |                  | (optional) Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default) |
+{{%/ tableWrapper %}}
+
+
 #### ScatterPlotWidget
 
 Renders a `<ScatterPlotWidget />` component, binded to a source at redux. The widget displays the calculations considering just the viewport features. From a data perspective, the ScatterPlotWidget represents two properties/columns in a cartesian chart from a data source to help understand if there is correlation between them.


### PR DESCRIPTION
Upgrade in the reference, so it includes the new pieces in the reference, coming from carto react 1.4.x (available from 1.4.1, reviewed with latest 1.4.2)