### PR TITLE
Add flag for local AT documentation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,25 @@ docker-compose up build
 
 Some projects have external files to be included in the documentation. Those files, generally the reference files, live in the main source code repository.
 
-To checkout the latest changes run:
+To checkout the latest changes in the remote repository:
 
 ```
 ./scripts/checkout.sh
 ```
 
-To update the reference files run:
+To checkout a certain branch of the documentation:
+
+```
+BRANCH=branch-name ./scripts/checkout.sh
+```
+
+And to review changes to review changes to the `docs/` directory in the Analytics Toolbox repo before publishing, use the **absolute** path to your local folder:
+
+```
+LOCAL_AT_PATH=~/path/to/analytics-toolbox ./scripts/checkout.sh
+```
+
+Once any of these versions is checked out, to update the reference files run:
 
 ```
 ./scripts/update.sh

--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
-BRACH=master
+BRANCH=master
 CHECKOUT_DIR=./.checkout
 
 rm -rf $CHECKOUT_DIR
 mkdir $CHECKOUT_DIR
 
-echo -e "\nCheckout Analytics Toolbox"
-echo "-------------------------------"
-git clone --branch $BRACH --depth 1 --recurse-submodules git@github.com:CartoDB/analytics-toolbox.git $CHECKOUT_DIR/analytics-toolbox
+if [ -z "$LOCAL_AT_PATH" ]; 
+then 
+    echo -e "\nCheckout Analytics Toolbox"
+    echo "-------------------------------"
+    git clone --branch $BRANCH \
+        --depth 1 \
+        --recurse-submodules \
+        git@github.com:CartoDB/analytics-toolbox.git \
+        $CHECKOUT_DIR/analytics-toolbox
+else 
+    echo -e "\nLinking local Analytics Toolbox"
+    ln -s "$LOCAL_AT_PATH" $CHECKOUT_DIR/analytics-toolbox
+fi


### PR DESCRIPTION
Include the `$LOCAL_AT_PATH` usage in the local checkout script, which allows to use a local folder via symbolic links to generate the AT docs files.

Now there are three main usages for the checkout script:

1. Include the AT documentation of the latest release in the default branch:

```shell
./scripts/checkout.sh && ./scripts/update.sh
```

2. Include the AT documentation of a given branch:

```shell
BRANCH=branch-name ./scripts/checkout.sh && ./scripts/update.sh
```

3. Use the new $LOCAL_AT_PATH to link a local copy of the repo:

```shell
LOCAL_AT_PATH=~/path/to/at ./scripts/checkout.sh && ./scripts/update.sh
```

The only caveat is that the value of the variable **must be an absolute path** (otherwise, the symbolic link will not work).

This PR also includes updates to the README that explain the three workflows.