### PR TITLE
Upgrade ubuntu-20.04 to ubuntu-24.04 runner version

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_and_preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -9,7 +9,7 @@ on:
         default: 'undefined'
 jobs:
   build_and_preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Set ref for the checkout


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/470573
- Autolink: [sc-470573]

In order to avoid deprecation and our CI/CD not running because we are using runners deprecated upgrade to the latest version available.